### PR TITLE
Convert | Implement 'toJson()' and 'toString()'

### DIFF
--- a/lib/src/excel.dart
+++ b/lib/src/excel.dart
@@ -550,6 +550,18 @@ class Excel {
     }
   }
 
+  Map<String, List<Map<String, dynamic>>> toJson() {
+    Map<String, List<Map<String, dynamic>>> json = {};
+
+    for (MapEntry sheet in sheets.entries) {
+      json[sheet.key] = sheet.value.toJson(); 
+    }
+
+    return json;
+  }
+
+  String toString() => 'Excel (sheets: $sheets)';
+
   ///
   ///Internal function taking care of adding the `sheetName` to the `mergeChangeLook` List
   ///So that merging function will be only called on `sheetNames of mergeChangeLook`
@@ -568,3 +580,5 @@ class Excel {
     }
   }
 }
+
+bool _isContain(dynamic val) => val != null; // (? Why is this function missing?)

--- a/lib/src/sheet/sheet.dart
+++ b/lib/src/sheet/sheet.dart
@@ -1291,6 +1291,30 @@ class Sheet {
     return <Data>[];
   }
 
+  List<Map<String, dynamic>> toJson() {
+    List<String>               header = List<String>.from(rows.first);
+    List<Map<String, dynamic>> data   = [];
+    Map<String, dynamic>       entry;
+    
+    for (int ir = 1; ir < rows.length; ir++) {
+      entry = {};
+
+      for (int ic = 0; ic < rows[ir].length; ic++) {
+        if (rows[ir][ic] is Formula) {
+          entry[header[ic]] = rows[ir][ic].value;
+        } else { 
+          entry[header[ic]] = rows[ir][ic];
+        }   
+      }
+
+      data.add(entry);
+    }
+
+    return data;
+  }
+
+  String toString() => 'Sheet (name: $_sheet, rows: $maxRows)';
+
   ///
   ///returns count of `rows` having data in `sheet`
   ///

--- a/test/excel_test.dart
+++ b/test/excel_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math';
 
 import 'package:excel/excel.dart';
 import 'package:test/test.dart';
@@ -16,6 +17,18 @@ void main() {
     var excel = Excel.decodeBytes(bytes);
     expect(excel.tables['Sheet1'].maxCols, equals(3));
     expect(excel.tables["Sheet1"].rows[1][1].toString(), equals('Washington'));
+  });
+
+  test('Convert XLSX File -> toJson()', () {
+    var file = "./test/test_resources/example.xlsx";
+    var bytes = File(file).readAsBytesSync();
+    var excel = Excel.decodeBytes(bytes);
+    var json  = excel.toJson();
+
+    expect(json, isMap);
+    expect(json, isNotEmpty);
+    expect(json.values.first.length, excel.sheets.values.first.maxRows - 1); // NO header row
+    expect(json.values.first.first.values.first, excel.sheets.values.first.rows[1].first);
   });
 
   group('Sheet Operations', () {


### PR DESCRIPTION
I would like to add this into the repo.

We are using excel primarily for importing purposes, so I had always convert into json format and I would like to have this in this library itself. 

Additionally I added `toString()` to `Excel` and `Sheet`, so a print will show more than `Instance of '#'`

Question:
When I cloned "_isContain()" was not defined? 
Remove this line after/before merge.