### PR TITLE
Fixed bug: type 'Null' is not a subtype of type 'List<int>' in type cast

### DIFF
--- a/lib/src/save/save_file.dart
+++ b/lib/src/save/save_file.dart
@@ -44,7 +44,7 @@ class Save {
         if (_archiveFiles.containsKey(file.name)) {
           copy = _archiveFiles[file.name]!;
         } else {
-          var content = (file.content as Uint8List).toList();
+          var content = file.content as Uint8List;
           var compress = !_noCompression.contains(file.name);
           copy = ArchiveFile(file.name, content.length, content)
             ..compress = compress;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,21 +7,21 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "19.0.0"
+    version: "34.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "3.2.0"
   archive:
     dependency: "direct main"
     description:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.2"
+    version: "3.2.0"
   args:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: equatable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.3"
   file:
     dependency: transitive
     description:
@@ -99,6 +99,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
   glob:
     dependency: transitive
     description:
@@ -147,14 +154,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -196,7 +203,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "4.4.0"
   pool:
     dependency: transitive
     description:
@@ -294,21 +301,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.8"
+    version: "1.20.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.19"
+    version: "0.4.11"
   typed_data:
     dependency: transitive
     description:
@@ -350,7 +357,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.2"
+    version: "5.3.1"
   yaml:
     dependency: transitive
     description:
@@ -359,4 +366,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: excel
 description: A flutter and dart library for reading, creating, editing and updating excel sheets with compatible both on client and server side.
-version: 2.0.0-null-safety-3
+version: 2.0.0-null-safety-4
 homepage: https://github.com/justkawal/excel
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  archive: ^3.1.2
-  xml: ^5.0.2
-  equatable: ^2.0.0
+  archive: ^3.2.0
+  xml: ^5.3.1
+  equatable: ^2.0.3
 
 dev_dependencies:
-  test: ^1.16.5
+  test: ^1.20.1


### PR DESCRIPTION
Anyone can use the null-safety branch while waiting for it to be released
```yaml
dependencies:
  # ...
  excel:
    git:
      url: https://github.com/chuyentt/excel.git
      ref: null-safety
```