### PR TITLE
Fixed README Code issue in "Find and Replace"

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ key | description
      * it returns the number of replacements made
      */
       
-      int replacedCount = sheetObject.findAndReplace(Flutter', 'Google');
+      int replacedCount = sheetObject.findAndReplace('Flutter', 'Google');
       
 ```
    


### PR DESCRIPTION
Added a ' for correct code highlighting in pub.dev and for correct code when copying and pasting