### PR TITLE
docs: update the package version number in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add this to your package's `pubspec.yaml` file:
 ```yaml
 dependencies:
   # From now on most of the changes and fixes will be pushed to null-safe versions only
-  excel: 2.0.0-null-safety
+  excel: ^2.0.0-null-safety-3
 ```
 
 ### 2. Install it


### PR DESCRIPTION
I installed the excel package according to the documentation, but the caching problem with the current `2.0.0-null-safety` version archive is causing me some problems, maybe we can update the version number in the documentation to the latest.

#91  #88 