### PR TITLE
fix bugs when parsing excel: 1. set fontColor in CellStyle; 2. set Cell…

### DIFF
--- a/lib/src/parser/parse.dart
+++ b/lib/src/parser/parse.dart
@@ -267,7 +267,7 @@ class Parser {
 
             /// Checking for font Size.
             var _clr = _nodeChildren(font, 'color', attribute: 'rgb');
-            if (_clr != null && _clr is bool && !_clr) {
+            if (_clr != null && !(_clr is bool)) {
               fontColor = _clr.toString();
             }
 
@@ -548,7 +548,8 @@ class Parser {
     }
     sheetObject.updateCell(
         CellIndex.indexByColumnRow(columnIndex: colIndex, rowIndex: rowIndex),
-        value);
+        value,
+        cellStyle: _excel._cellStyleList[s]);
     if (value.runtimeType == String) {
       _excel._sharedStrings.add(value);
     }
@@ -584,7 +585,7 @@ class Parser {
   ///
   ///
   _createSheet(String newSheet) {
-    /* 
+    /*
     List<XmlNode> list = _excel._xmlFiles['xl/workbook.xml']
         .findAllElements('sheets')
         .first


### PR DESCRIPTION
when parsing excel, I found there was a bug that cells had not `cellStyle`, and further more all the `fontColor` of `cellStyles` in `_cellStyleList` are `"FF000000"`, so I edit parse.dart, and fixed these bugs.