### PR TITLE
Add support for headers and footers

### DIFF
--- a/lib/excel.dart
+++ b/lib/excel.dart
@@ -36,3 +36,4 @@ part 'src/sheet/formula.dart';
 part 'src/sheet/cell_index.dart';
 part 'src/sheet/cell_style.dart';
 part 'src/sheet/font_style.dart';
+part 'src/sheet/header_footer.dart';

--- a/lib/src/parser/parse.dart
+++ b/lib/src/parser/parse.dart
@@ -439,6 +439,8 @@ class Parser {
       _parseRow(child, sheetObject, name);
     });
 
+    _parseHeaderFooter(worksheet, sheetObject);
+
     _excel._sheets[name] = sheet;
 
     _excel._xmlFiles['xl/$target'] = content;
@@ -688,5 +690,14 @@ class Parser {
     if (_excel._xmlFiles['xl/workbook.xml'] != null)
       _parseTable(
           _excel._xmlFiles['xl/workbook.xml']!.findAllElements('sheet').last);
+  }
+
+  void _parseHeaderFooter(XmlElement worksheet, Sheet sheetObject) {
+    final results = worksheet.findAllElements("headerFooter");
+    if (results.isEmpty) return;
+
+    final headerFooterElement = results.first;
+
+    sheetObject.headerFooter = HeaderFooter.fromXmlElement(headerFooterElement);
   }
 }

--- a/lib/src/save/save_file.dart
+++ b/lib/src/save/save_file.dart
@@ -130,6 +130,8 @@ class Save {
           }
         }
       }
+
+      _setHeaderFooter(sheet);
     });
   }
 
@@ -763,5 +765,24 @@ class Save {
     var cell = _createCell(sheet, columnIndex, rowIndex, value);
     row.children.add(cell);
     return cell;
+  }
+
+  void _setHeaderFooter(String sheetName) {
+    final sheet = _excel._sheetMap[sheetName];
+    if (sheet == null) return;
+
+    final xmlFile = _excel._xmlFiles[_excel._xmlSheetId[sheetName]];
+    if (xmlFile == null) return;
+
+    final sheetXmlElement = xmlFile.findAllElements("worksheet").first;
+
+    final results = sheetXmlElement.findAllElements("headerFooter");
+    if (results.isNotEmpty) {
+      sheetXmlElement.children.remove(results.first);
+    }
+
+    if (sheet.headerFooter == null) return;
+
+    sheetXmlElement.children.add(sheet.headerFooter!.toXmlElement());
   }
 }

--- a/lib/src/sheet/header_footer.dart
+++ b/lib/src/sheet/header_footer.dart
@@ -1,0 +1,195 @@
+part of excel;
+
+class HeaderFooter {
+  late bool? _alignWithMargins;
+  late bool? _differentFirst;
+  late bool? _differentOddEven;
+  late bool? _scaleWithDoc;
+
+  late String? _evenFooter;
+  late String? _evenHeader;
+  late String? _firstFooter;
+  late String? _firstHeader;
+  late String? _oddFooter;
+  late String? _oddHeader;
+
+  HeaderFooter({
+    bool? alignWithMargins = null,
+    bool? differentFirst = null,
+    bool? differentOddEven = null,
+    bool? scaleWithDoc = null,
+    String? evenFooter = null,
+    String? evenHeader = null,
+    String? firstFooter = null,
+    String? firstHeader = null,
+    String? oddFooter = null,
+    String? oddHeader = null,
+  })  : _alignWithMargins = alignWithMargins,
+        _differentFirst = differentFirst,
+        _differentOddEven = differentOddEven,
+        _scaleWithDoc = scaleWithDoc,
+        _evenFooter = evenFooter,
+        _evenHeader = evenHeader,
+        _firstFooter = firstFooter,
+        _firstHeader = firstHeader,
+        _oddFooter = oddFooter,
+        _oddHeader = oddHeader;
+
+  bool? get alignWithMargins {
+    return _alignWithMargins;
+  }
+
+  set alignWithMargins(bool? alignWithMargins) {
+    _alignWithMargins = alignWithMargins;
+  }
+
+  bool? get differentFirst {
+    return _differentFirst;
+  }
+
+  set differentFist(bool? differentFirst) {
+    _differentFirst = differentFirst;
+  }
+
+  bool? get differentOddEven {
+    return _differentOddEven;
+  }
+
+  set differentOddEven(bool? differentOddEven) {
+    _differentOddEven = differentOddEven;
+  }
+
+  bool? get scaleWithDoc {
+    return _scaleWithDoc;
+  }
+
+  set scaleWithDoc(bool? scaleWithDoc) {
+    _scaleWithDoc = scaleWithDoc;
+  }
+
+  String? get evenFooter {
+    return _evenFooter;
+  }
+
+  set evenFooter(String? evenFooter) {
+    _evenFooter = evenFooter;
+  }
+
+  String? get evenHeader {
+    return _evenHeader;
+  }
+
+  set evenHeader(String? evenHeader) {
+    _evenHeader = evenHeader;
+  }
+
+  String? get firstFooter {
+    return _firstFooter;
+  }
+
+  set firstFooter(String? firstFooter) {
+    _firstFooter = firstFooter;
+  }
+
+  String? get firstHeader {
+    return _firstHeader;
+  }
+
+  set firstHeader(String? firstHeader) {
+    _firstHeader = firstHeader;
+  }
+
+  String? get oddFooter {
+    return _oddFooter;
+  }
+
+  set oddFooter(String? oddFooter) {
+    _oddFooter = oddFooter;
+  }
+
+  String? get oddHeader {
+    return _oddHeader;
+  }
+
+  set oddHeader(String? oddHeader) {
+    _oddHeader = oddHeader;
+  }
+
+  XmlNode toXmlElement() {
+    final attributes = <XmlAttribute>[];
+    if (_alignWithMargins != null) {
+      attributes.add(XmlAttribute(
+          XmlName("alignWithMargins"), _alignWithMargins.toString()));
+    }
+    if (_differentFirst != null) {
+      attributes.add(
+          XmlAttribute(XmlName("differentFirst"), _differentFirst.toString()));
+    }
+    if (_differentOddEven != null) {
+      attributes.add(XmlAttribute(
+          XmlName("differentOddEven"), _differentOddEven.toString()));
+    }
+    if (_scaleWithDoc != null) {
+      attributes
+          .add(XmlAttribute(XmlName("scaleWithDoc"), _scaleWithDoc.toString()));
+    }
+
+    final children = <XmlNode>[];
+    if (_evenFooter != null) {
+      children
+          .add(XmlElement(XmlName("evenFooter"), [], [XmlText(_evenFooter!)]));
+    }
+    if (_evenHeader != null) {
+      children
+          .add(XmlElement(XmlName("evenHeader"), [], [XmlText(_evenHeader!)]));
+    }
+    if (_firstFooter != null) {
+      children.add(
+          XmlElement(XmlName("firstFooter"), [], [XmlText(_firstFooter!)]));
+    }
+    if (_firstHeader != null) {
+      children.add(
+          XmlElement(XmlName("firstHeader"), [], [XmlText(_firstHeader!)]));
+    }
+    if (_oddFooter != null) {
+      children
+          .add(XmlElement(XmlName("oddFooter"), [], [XmlText(_oddFooter!)]));
+    }
+    if (_oddHeader != null) {
+      children
+          .add(XmlElement(XmlName("oddHeader"), [], [XmlText(_oddHeader!)]));
+    }
+
+    return XmlElement(XmlName("headerFooter"), attributes, children);
+  }
+
+  static HeaderFooter fromXmlElement(XmlElement headerFooterElement) {
+    return HeaderFooter(
+        alignWithMargins:
+            headerFooterElement.getAttribute("alignWithMargins")?.parseBool(),
+        differentFirst:
+            headerFooterElement.getAttribute("differentFirst")?.parseBool(),
+        differentOddEven:
+            headerFooterElement.getAttribute("differentOddEven")?.parseBool(),
+        scaleWithDoc:
+            headerFooterElement.getAttribute("scaleWithDoc")?.parseBool(),
+        evenFooter: headerFooterElement.getElement("evenFooter")?.innerXml,
+        evenHeader: headerFooterElement.getElement("evenHeader")?.innerXml,
+        firstFooter: headerFooterElement.getElement("firstFooter")?.innerXml,
+        firstHeader: headerFooterElement.getElement("firstHeader")?.innerXml,
+        oddFooter: headerFooterElement.getElement("oddFooter")?.innerXml,
+        oddHeader: headerFooterElement.getElement("oddHeader")?.innerXml);
+  }
+}
+
+extension BoolParsing on String {
+  bool parseBool() {
+    if (this.toLowerCase() == 'true') {
+      return true;
+    } else if (this.toLowerCase() == 'false') {
+      return false;
+    }
+
+    throw '"$this" can not be parsed to boolean.';
+  }
+}

--- a/lib/src/sheet/sheet.dart
+++ b/lib/src/sheet/sheet.dart
@@ -11,6 +11,7 @@ class Sheet {
   late FastList<String> _spannedItems;
   late List<_Span?> _spanList;
   late Map<int, Map<int, Data>> _sheetData;
+  late HeaderFooter? _headerFooter;
 
   ///
   /// It will clone the object by changing the `this` reference of previous oldSheetObject and putting `new this` reference, with copying the values too
@@ -1321,5 +1322,13 @@ class Sheet {
   ///
   int get maxCols {
     return _maxCols;
+  }
+
+  HeaderFooter? get headerFooter {
+    return _headerFooter;
+  }
+
+  set headerFooter(HeaderFooter? headerFooter) {
+    _headerFooter = headerFooter;
   }
 }

--- a/test/excel_test.dart
+++ b/test/excel_test.dart
@@ -93,4 +93,29 @@ void main() {
     expect(newExcel.tables['Sheet1']!.rows[4][1]!.value.toString(),
         equals('Moscow'));
   });
+
+  test("Update header/footer", () {
+    var file = './test/test_resources/example.xlsx';
+    var bytes = File(file).readAsBytesSync();
+    var excel = Excel.decodeBytes(bytes);
+    Sheet? sheetObject = excel.tables['Sheet1']!;
+
+    sheetObject.headerFooter!.oddHeader = "Foo";
+    sheetObject.headerFooter!.oddFooter = "Bar";
+
+    var fileBytes = excel.encode();
+    if (fileBytes != null) {
+      File(Directory.current.path + '/tmp/exampleOut.xlsx')
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(fileBytes);
+    }
+    var newFile = './tmp/exampleOut.xlsx';
+    var newFileBytes = File(newFile).readAsBytesSync();
+    var newExcel = Excel.decodeBytes(newFileBytes);
+    expect(newExcel.tables['Sheet1']!.headerFooter!.oddHeader!, equals('Foo'));
+    expect(newExcel.tables['Sheet1']!.headerFooter!.oddFooter!, equals('Bar'));
+
+    // delete tmp folder only when test is successful (diagnosis)
+    new Directory('./tmp').delete(recursive: true);
+  });
 }


### PR DESCRIPTION
This pull request adds support for the reading/writing headers and footers (headerFooter element). The HeaderFooter class exposes the raw content of the odd/even header/footer elements. All formatting [codes](https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_evenHeader_topic_ID0EJKY4.html#topic_ID0EJKY4) must be handled manually.