### PR TITLE
Remove section of incompatible dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,13 +477,6 @@ For getting saving directory on Android or iOS, Use: [path_provider](https://pub
        ..createSync(recursive: true)
        ..writeAsBytesSync(fileBytes);
 ```
- 
-# Frequent Issues
-
-### Having Trouble using excel i.e: ```every version of some_other_library depends on version..... blah blah blah```
-
-```Similar issues have been solved in the past :``` [#26](https://github.com/justkawal/excel/issues/26), [#25](https://github.com/justkawal/excel/issues/25), [#11](https://github.com/justkawal/excel/issues/11)
-
 
 ## Features coming in next version
 On-going implementation for future:


### PR DESCRIPTION
Removes the README section where the dependency constraints are explained, as these issues have been fixed 2 months ago. This part can safely be removed, and this change should also be reflected on the README on pub.dev.