### PR TITLE
support sharedStrings absolute path

### DIFF
--- a/lib/src/excel.dart
+++ b/lib/src/excel.dart
@@ -46,6 +46,12 @@ class Excel {
 
   late String _stylesTarget;
   late String _sharedStringsTarget;
+  String get _absSharedStringsTarget{
+    if(_sharedStringsTarget.isNotEmpty && _sharedStringsTarget[0] == "/"){
+      return _sharedStringsTarget.substring(1);
+    }
+    return "xl/${_sharedStringsTarget}";
+  }
 
   String? _defaultSheet;
   late Parser parser;

--- a/lib/src/parser/parse.dart
+++ b/lib/src/parser/parse.dart
@@ -70,8 +70,7 @@ class Parser {
   }
 
   _parseSharedStrings() {
-    var sharedStrings =
-        _excel._archive.findFile('xl/${_excel._sharedStringsTarget}');
+    var sharedStrings = _excel._archive.findFile(_excel._absSharedStringsTarget);
     if (sharedStrings == null) {
       _excel._sharedStringsTarget = 'sharedStrings.xml';
 
@@ -127,10 +126,8 @@ class Parser {
 
       var content = utf8.encode(
           "<sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"0\" uniqueCount=\"0\"/>");
-      _excel._archive.addFile(ArchiveFile(
-          'xl/${_excel._sharedStringsTarget}', content.length, content));
-      sharedStrings =
-          _excel._archive.findFile('xl/${_excel._sharedStringsTarget}');
+      _excel._archive.addFile(ArchiveFile("xl/sharedStrings.xml", content.length, content));
+      sharedStrings = _excel._archive.findFile("xl/sharedStrings.xml");
     }
     sharedStrings!.decompress();
     var document = XmlDocument.parse(utf8.decode(sharedStrings.content));


### PR DESCRIPTION
some lib creating excel file will use absolute path in Relationship, such as go-excelize.
in this case, cell value can not be read correctly.