### PR TITLE
Assign return value of replaceAll

### DIFF
--- a/lib/src/sheet/sheet.dart
+++ b/lib/src/sheet/sheet.dart
@@ -1144,7 +1144,7 @@ class Sheet {
             _sheetData[i]![j] != null &&
             sourceRegx.hasMatch(_sheetData[i]![j]!.value.toString()) &&
             (first == -1 || first != replaceCount)) {
-          _sheetData[i]![j]!
+          _sheetData[i]![j]!.value = _sheetData[i]![j]!
               .value
               .toString()
               .replaceAll(sourceRegx, target.toString());


### PR DESCRIPTION
Currently using `findAndReplace` returns the number of theoretical replacements but doesn't actually replace anything. That is because the value of `replaceAll(sourceRegx, target.toString())` inside `findAndReplace` isn't assigned back to the sheet data, making the call practically a noop.