### PR TITLE
On hashCode equal, verify using string data

### DIFF
--- a/lib/src/sharedStrings/shared_strings.dart
+++ b/lib/src/sharedStrings/shared_strings.dart
@@ -96,5 +96,12 @@ class SharedString {
   int get hashCode => _hashCode;
 
   @override
-  operator ==(Object other) => other.hashCode == _hashCode;
+  operator ==(Object other) {
+    if (other.hashCode == _hashCode) {
+      if (other.toString() == toString()) {
+        return true;
+      }
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
Hey so this is a quick simple fix for everyone who is having issues with cells containing the wrong data.

Overall, while quick, HashCode should not be used as a Key as they are non-unique.  To keep some semblance of speed we can continue to have it verify through hash, but if they run into the same data then it would need to verify through the string data itself.


Yes this will slow things down on large excels, but that is when it is needed the most.
Some tests I was doing with my real world data took my decode times from ~5s to ~5.5s and in my larger file from ~9.2s to 9.9s. Again to be clear, the "faster" files were corrupted by this issue so being faster in the case meant nothing.

I think this relates to a few different errors people are getting and likely a lot of errors that are going unnoticed. In my case it was random cells appearing in different places and having everything shifted over by 1 in some places. As it got worse my excel would start looking like a jumbled mess.
#159 