### PR TITLE
Add setRowHeight & a way to set default column width and row height

### DIFF
--- a/example/excel_custom_size.dart
+++ b/example/excel_custom_size.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
-import 'package:path/path.dart';
 
 import '../lib/excel.dart';
 
@@ -35,22 +34,25 @@ void main(List<String> args) {
         .value = getRandString();
   }
 
-  sheet.setColWidth(0, 10.0);
-  sheet.setColWidth(1, 10.0);
-  sheet.setColAutoFit(0);
-  sheet.setColAutoFit(1);
-  sheet.setColAutoFit(2);
-  sheet.setColWidth(50, 10.0);
+  sheet.setColumnAutoFit(0);
+  sheet.setColumnAutoFit(1);
+  sheet.setColumnAutoFit(2);
+
+  sheet.setColumnWidth(0, 10.0);
+  sheet.setColumnWidth(1, 10.0);
+  sheet.setColumnWidth(50, 10.0);
+  
+  sheet.setRowHeight(1, 100);
 
   sheet.merge(CellIndex.indexByColumnRow(columnIndex: 0, rowIndex: 0),
       CellIndex.indexByColumnRow(columnIndex: 1, rowIndex: 10));
 
-  String outputFile =
-      "/Users/igdmitrov/Downloads/excel_custom-${DateTime.now().toIso8601String()}.xlsx";
+  // Create the example excel file in the current directory
+  String outputFile = "excel_custom.xlsx";
 
   List<int>? fileBytes = excel.save();
   if (fileBytes != null) {
-    File(join(outputFile))
+    File(outputFile)
       ..createSync(recursive: true)
       ..writeAsBytesSync(fileBytes);
   }

--- a/lib/src/save/save_file.dart
+++ b/lib/src/save/save_file.dart
@@ -121,12 +121,12 @@ class Save {
     return XmlElement(XmlName('c'), attributes, children);
   }
 
-  ///
+  /// Create a new row in the sheet.
   XmlElement _createNewRow(XmlElement table, int rowIndex, double? height) {
     var row = XmlElement(XmlName('row'), [
       XmlAttribute(XmlName('r'), (rowIndex + 1).toString()),
       if (height != null) XmlAttribute(XmlName('ht'), height.toString()),
-      XmlAttribute(XmlName('customHeight'), '1'),
+      if (height != null) XmlAttribute(XmlName('customHeight'), '1'),
     ], []);
     table.children.add(row);
     return row;

--- a/lib/src/sheet/sheet.dart
+++ b/lib/src/sheet/sheet.dart
@@ -6,8 +6,11 @@ class Sheet {
   late bool _isRTL;
   late int _maxRows;
   late int _maxCols;
-  List<double> _colWidth = <double>[];
-  List<bool> _colAutoFit = <bool>[];
+  double _defaultColumnWidth = _excelDefaultColumnWidth;
+  double _defaultRowHeight = _excelDefaultRowHeight;
+  Map<int, double> _columnWidths = {};
+  Map<int, double> _rowHeights = {};
+  Map<int, bool> _columnAutoFit = {};
   late FastList<String> _spannedItems;
   late List<_Span?> _spanList;
   late Map<int, Map<int, Data>> _sheetData;
@@ -23,8 +26,9 @@ class Sheet {
             spanI_: oldSheetObject._spannedItems,
             maxRowsVal: oldSheetObject._maxRows,
             maxColsVal: oldSheetObject._maxCols,
-            colWidthVal: oldSheetObject._colWidth,
-            colAutoFitVal: oldSheetObject._colAutoFit,
+            columnWidthsVal: oldSheetObject._columnWidths,
+            rowHeightsVal: oldSheetObject._rowHeights,
+            columnAutoFitVal: oldSheetObject._columnAutoFit,
             isRTLVal: oldSheetObject._isRTL,
             headerFooter: oldSheetObject._headerFooter);
 
@@ -35,8 +39,9 @@ class Sheet {
       int? maxRowsVal,
       int? maxColsVal,
       bool? isRTLVal,
-      List<double>? colWidthVal,
-      List<bool>? colAutoFitVal,
+      Map<int, double>? columnWidthsVal,
+      Map<int, double>? rowHeightsVal,
+      Map<int, bool>? columnAutoFitVal,
       HeaderFooter? headerFooter}) {
     _excel = excel;
     _sheet = sheetName;
@@ -65,11 +70,14 @@ class Sheet {
       _isRTL = isRTLVal;
       _excel._rtlChangeLookup = sheetName;
     }
-    if (colWidthVal != null) {
-      _colWidth = List<double>.from(colWidthVal);
+    if (columnWidthsVal != null) {
+      _columnWidths = Map<int, double>.from(columnWidthsVal);
     }
-    if (colAutoFitVal != null) {
-      _colAutoFit = List<bool>.from(colAutoFitVal);
+    if (rowHeightsVal != null) {
+      _rowHeights = Map<int, double>.from(rowHeightsVal);
+    }
+    if (columnAutoFitVal != null) {
+      _columnAutoFit = Map<int, bool>.from(columnAutoFitVal);
     }
 
     /// copy the data objects into a temp folder and then while putting it into `_sheetData` change the data objects references.
@@ -1001,59 +1009,60 @@ class Sheet {
     //_countRowAndCol();
   }
 
-  ///
-  /// returns list of auto fit columns
-  ///
-  List<bool> get getColAutoFits {
-    return _colAutoFit;
-  }
+  double get defaultRowHeight => _defaultRowHeight;
+
+  double get defaultColumnWidth => _defaultColumnWidth;
 
   ///
-  /// returns list of custom width columns
+  /// returns map of auto fit columns
   ///
-  List<double> get getColWidths {
-    return _colWidth;
-  }
+  Map<int, bool> get getColumnAutoFit => _columnAutoFit;
 
   ///
-  /// Get Column AutoFit
+  /// returns map of custom width columns
   ///
-  bool getColAutoFit(int colIndex) {
-    _checkMaxCol(colIndex);
-    return _colAutoFit[colIndex];
-  }
+  Map<int, double> get getColWidths => _columnWidths;
 
   ///
-  /// Get Column Width
+  /// returns map of custom height rows
   ///
-  double getColWidth(int colIndex) {
-    _checkMaxCol(colIndex);
-    return _colWidth[colIndex];
+  Map<int, double> get getRowHeights => _rowHeights;
+
+  void setDefaultRowHeight(double rowHeight) {
+    if (rowHeight < 0) return;
+    _defaultRowHeight = rowHeight;
+  }
+
+  void setDefaultColumnWidth(double colWidth) {
+    if (colWidth < 0) return;
+    _defaultColumnWidth = colWidth;
   }
 
   ///
   /// Set Column AutoFit
   ///
-  void setColAutoFit(int colIndex) {
-    _checkMaxCol(colIndex);
-
-    while (colIndex >= _colAutoFit.length) {
-      _colAutoFit.add(false);
-    }
-    _colAutoFit[colIndex] = true;
+  void setColumnAutoFit(int columnIndex) {
+    _checkMaxCol(columnIndex);
+    if (columnIndex < 0) return;
+    _columnAutoFit[columnIndex] = true;
   }
 
   ///
   /// Set Column Width
   ///
-  void setColWidth(int colIndex, double colWidth) {
-    _checkMaxCol(colIndex);
-    if (colWidth < 0) return;
+  void setColumnWidth(int columnIndex, double columnWidth) {
+    _checkMaxCol(columnIndex);
+    if (columnWidth < 0) return;
+    _columnWidths[columnIndex] = columnWidth;
+  }
 
-    while (colIndex >= _colWidth.length) {
-      _colWidth.add(_defaultColumnWidth);
-    }
-    _colWidth[colIndex] = colWidth;
+  ///
+  /// Set Row Height
+  ///
+  void setRowHeight(int rowIndex, double rowHeight) {
+    _checkMaxRow(rowIndex);
+    if (rowHeight < 0) return;
+    _rowHeights[rowIndex] = rowHeight;
   }
 
   CellType _getCellType(var type) {

--- a/lib/src/utilities/constants.dart
+++ b/lib/src/utilities/constants.dart
@@ -14,4 +14,6 @@ const _relationships =
 
 const _spreasheetXlsx = 'xlsx';
 
-const _defaultColumnWidth = 14.75;
+// reference: https://support.microsoft.com/en-gb/office/change-the-column-width-and-row-height-72f5e3cc-994d-43e8-ae58-9774a0905f46
+const _excelDefaultColumnWidth = 8.43;
+const _excelDefaultRowHeight = 15.0;


### PR DESCRIPTION
Dear justkawal,

I was recently writing a project that involves setting the width and height of an exported excel table. During my exploration of the available methods, I came across the `setColWidth` function. However, upon further investigation of the related issues and PRs, I noticed that the `setRowHeight` method, which was intended to be added in #99, seemed to have been unintentionally removed or overlooked. So,  I invested some time into fixing that. And at the mean time, I added a way to set default column width and row height.

I hope that proves valuable to the project. Thank you for your time and consideration.