### PR TITLE
Refactor Span

### DIFF
--- a/lib/src/parser/parse.dart
+++ b/lib/src/parser/parse.dart
@@ -187,11 +187,12 @@ class Parser {
           }
           spannedCells[sheetName] = spanList;
 
-          List<int> startIndex = _cellCoordsFromCellId(startCell),
-              endIndex = _cellCoordsFromCellId(endCell);
-          _Span spanObj = _Span();
-          spanObj._start = [startIndex[0], startIndex[1]];
-          spanObj._end = [endIndex[0], endIndex[1]];
+          CellIndex startIndex = CellIndex.indexByString(startCell),
+              endIndex = CellIndex.indexByString(endCell);
+          _Span spanObj = _Span.fromCellIndex(
+            start: startIndex,
+            end: endIndex,
+          );
           if (!_excel._sheetMap[sheetName]!._spanList.contains(spanObj)) {
             _excel._sheetMap[sheetName]!._spanList.add(spanObj);
           }

--- a/lib/src/save/self_correct_span.dart
+++ b/lib/src/save/self_correct_span.dart
@@ -52,9 +52,12 @@ _selfCorrectSpanMap(Excel _excel) {
             }
           }
         }
-        _Span spanObj1 = _Span();
-        spanObj1._start = [startRow, startColumn];
-        spanObj1._end = [endRow, endColumn];
+        _Span spanObj1 = _Span(
+          rowSpanStart: startRow,
+          columnSpanStart: startColumn,
+          rowSpanEnd: endRow,
+          columnSpanEnd: endColumn,
+        );
         spanList[i] = spanObj1;
       }
       _excel._sheetMap[key]!._spanList = List<_Span?>.from(spanList);

--- a/lib/src/sheet/sheet.dart
+++ b/lib/src/sheet/sheet.dart
@@ -324,7 +324,6 @@ class Sheet {
           endRow = spanObj.rowSpanEnd;
 
       if (columnIndex <= endColumn) {
-        _Span newSpanObj = _Span();
         if (columnIndex < startColumn) {
           startColumn -= 1;
         }
@@ -337,8 +336,12 @@ class Sheet {
                         : startColumn))) {
           _spanList[i] = null;
         } else {
-          newSpanObj._start = [startRow, startColumn];
-          newSpanObj._end = [endRow, endColumn];
+          _Span newSpanObj = _Span(
+            rowSpanStart: startRow,
+            columnSpanStart: startColumn,
+            rowSpanEnd: endRow,
+            columnSpanEnd: endColumn,
+          );
           _spanList[i] = newSpanObj;
         }
         updateSpanCell = true;
@@ -417,13 +420,16 @@ class Sheet {
           endRow = spanObj.rowSpanEnd;
 
       if (columnIndex <= endColumn) {
-        _Span newSpanObj = _Span();
         if (columnIndex <= startColumn) {
           startColumn += 1;
         }
         endColumn += 1;
-        newSpanObj._start = [startRow, startColumn];
-        newSpanObj._end = [endRow, endColumn];
+        _Span newSpanObj = _Span(
+          rowSpanStart: startRow,
+          columnSpanStart: startColumn,
+          rowSpanEnd: endRow,
+          columnSpanEnd: endColumn,
+        );
         _spanList[i] = newSpanObj;
         updateSpanCell = true;
         _excel._mergeChanges = true;
@@ -511,7 +517,6 @@ class Sheet {
           endRow = spanObj.rowSpanEnd;
 
       if (rowIndex <= endRow) {
-        _Span newSpanObj = _Span();
         if (rowIndex < startRow) {
           startRow -= 1;
         }
@@ -521,8 +526,12 @@ class Sheet {
                 (rowIndex == (rowIndex < startRow ? startRow + 1 : startRow))) {
           _spanList[i] = null;
         } else {
-          newSpanObj._start = [startRow, startColumn];
-          newSpanObj._end = [endRow, endColumn];
+          _Span newSpanObj = _Span(
+            rowSpanStart: startRow,
+            columnSpanStart: startColumn,
+            rowSpanEnd: endRow,
+            columnSpanEnd: endColumn,
+          );
           _spanList[i] = newSpanObj;
         }
         updateSpanCell = true;
@@ -599,13 +608,16 @@ class Sheet {
           endRow = spanObj.rowSpanEnd;
 
       if (rowIndex <= endRow) {
-        _Span newSpanObj = _Span();
         if (rowIndex <= startRow) {
           startRow += 1;
         }
         endRow += 1;
-        newSpanObj._start = [startRow, startColumn];
-        newSpanObj._end = [endRow, endColumn];
+        _Span newSpanObj = _Span(
+          rowSpanStart: startRow,
+          columnSpanStart: startColumn,
+          rowSpanEnd: endRow,
+          columnSpanEnd: endColumn,
+        );
         _spanList[i] = newSpanObj;
         updateSpanCell = true;
         _excel._mergeChanges = true;
@@ -761,9 +773,12 @@ class Sheet {
       _spannedItems.add(sp);
     }
 
-    _Span s = _Span();
-    s._start = [startRow, startColumn];
-    s._end = [endRow, endColumn];
+    _Span s = _Span(
+      rowSpanStart: startRow,
+      columnSpanStart: startColumn,
+      rowSpanEnd: endRow,
+      columnSpanEnd: endColumn,
+    );
 
     _spanList.add(s);
     _excel._mergeChangeLookup = sheetName;
@@ -784,20 +799,18 @@ class Sheet {
       List<String> lis = unmergeCells.split(RegExp(r":"));
       if (lis.length == 2) {
         bool remove = false;
-        List<int> start, end;
-        start =
-            _cellCoordsFromCellId(lis[0]); // [x,y] => [startRow, startColumn]
-        end = _cellCoordsFromCellId(lis[1]); // [x,y] => [endRow, endColumn]
+        CellIndex start = CellIndex.indexByString(lis[0]),
+            end = CellIndex.indexByString(lis[1]);
         for (int i = 0; i < _spanList.length; i++) {
           _Span? spanObject = _spanList[i];
           if (spanObject == null) {
             continue;
           }
 
-          if (spanObject.columnSpanStart == start[1] &&
-              spanObject.rowSpanStart == start[0] &&
-              spanObject.columnSpanEnd == end[1] &&
-              spanObject.rowSpanEnd == end[0]) {
+          if (spanObject.columnSpanStart == start.columnIndex &&
+              spanObject.rowSpanStart == start.rowIndex &&
+              spanObject.columnSpanEnd == end.columnIndex &&
+              spanObject.rowSpanEnd == end.rowIndex) {
             _spanList[i] = null;
             remove = true;
           }

--- a/lib/src/utilities/span.dart
+++ b/lib/src/utilities/span.dart
@@ -1,45 +1,32 @@
 part of excel;
 
 // For Spanning the columns and rows
-// ignore: must_be_immutable
 class _Span extends Equatable {
-  late List<int> __start;
-  late List<int> __end;
+  final int rowSpanStart;
+  final int columnSpanStart;
+  final int rowSpanEnd;
+  final int columnSpanEnd;
 
-  _Span() {
-    __start = <int>[];
-    __end = <int>[];
-  }
+  _Span({
+    required this.rowSpanStart,
+    required this.columnSpanStart,
+    required this.rowSpanEnd,
+    required this.columnSpanEnd,
+  });
 
-  set _start(List<int> val) {
-    __start = val;
-  }
-
-  set _end(List<int> val) {
-    __end = val;
-  }
-
-  int get rowSpanStart {
-    return __start[0];
-  }
-
-  int get rowSpanEnd {
-    return __end[0];
-  }
-
-  int get columnSpanStart {
-    return __start[1];
-  }
-
-  int get columnSpanEnd {
-    return __end[1];
-  }
+  _Span.fromCellIndex({
+    required CellIndex start,
+    required CellIndex end,
+  })  : rowSpanStart = start.rowIndex,
+        columnSpanStart = start.columnIndex,
+        rowSpanEnd = end.rowIndex,
+        columnSpanEnd = end.columnIndex;
 
   @override
   List<Object?> get props => [
-        __start[0],
-        __start[1],
-        __end[0],
-        __end[1],
+        rowSpanStart,
+        columnSpanStart,
+        rowSpanEnd,
+        columnSpanEnd,
       ];
 }


### PR DESCRIPTION
- Use `CellIndex` data type instead of `List<int>` if possible
- Avoid unnecessary use of private variables
- Force the Span constructor to receive required fields