### PR TITLE
Fix XML deprecated properties

### DIFF
--- a/lib/src/parser/parse.dart
+++ b/lib/src/parser/parse.dart
@@ -622,7 +622,7 @@ class Parser {
 
     node.children.forEach((child) {
       if (child is XmlText) {
-        buffer.write(_normalizeNewLine(child.text));
+        buffer.write(_normalizeNewLine(child.value));
       }
     });
 

--- a/lib/src/sheet/header_footer.dart
+++ b/lib/src/sheet/header_footer.dart
@@ -84,12 +84,12 @@ class HeaderFooter {
             headerFooterElement.getAttribute("differentOddEven")?.parseBool(),
         scaleWithDoc:
             headerFooterElement.getAttribute("scaleWithDoc")?.parseBool(),
-        evenHeader: headerFooterElement.getElement("evenHeader")?.text,
-        evenFooter: headerFooterElement.getElement("evenFooter")?.text,
-        firstHeader: headerFooterElement.getElement("firstHeader")?.text,
-        firstFooter: headerFooterElement.getElement("firstFooter")?.text,
-        oddFooter: headerFooterElement.getElement("oddFooter")?.text,
-        oddHeader: headerFooterElement.getElement("oddHeader")?.text);
+        evenHeader: headerFooterElement.getElement("evenHeader")?.innerText,
+        evenFooter: headerFooterElement.getElement("evenFooter")?.innerText,
+        firstHeader: headerFooterElement.getElement("firstHeader")?.innerText,
+        firstFooter: headerFooterElement.getElement("firstFooter")?.innerText,
+        oddFooter: headerFooterElement.getElement("oddFooter")?.innerText,
+        oddHeader: headerFooterElement.getElement("oddHeader")?.innerText);
   }
 }
 


### PR DESCRIPTION
Fixes `XmlNode.text` being deprecated since `xml 6.3.0`.

https://pub.dev/packages/xml/changelog#630