### PR TITLE
Scientific notation number parsing

### DIFF
--- a/lib/src/number_format/num_format.dart
+++ b/lib/src/number_format/num_format.dart
@@ -262,8 +262,11 @@ sealed class NumericNumFormat extends NumFormat {
 
   @override
   CellValue read(String v) {
+    // check if scientific notation e.g. 1E-3
+    final eIdx = v.indexOf('E');
     final decimalSeparatorIdx = v.indexOf('.');
-    if (decimalSeparatorIdx == -1) {
+
+    if (decimalSeparatorIdx == -1 && eIdx == -1) {
       return IntCellValue(int.parse(v));
     }
 


### PR DESCRIPTION
Fixes a parsing exception for excel numeric cells with numbers like 0.001, which are saved as scientific notation "1E-3"