### PR TITLE
Update data_model error at int or double cell

### DIFF
--- a/lib/src/sheet/data_model.dart
+++ b/lib/src/sheet/data_model.dart
@@ -137,7 +137,7 @@ class IntCellValue extends CellValue {
 
   @override
   String toString() {
-    return value.toString();
+    return '$value';
   }
 
   @override
@@ -156,7 +156,7 @@ class DoubleCellValue extends CellValue {
 
   @override
   String toString() {
-    return value.toString();
+    return '$value';
   }
 
   @override


### PR DESCRIPTION
I think this change solves the following error:

Error: Exception: null does not work for IntCellValue
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 294:3       throw_
packages/excel/src/save/save_file.dart 124:16                                     <fn>
packages/excel/src/save/save_file.dart 124:13                                     [_createCell]
packages/excel/src/save/save_file.dart 997:16                                     [_updateCell]
packages/excel/src/save/save_file.dart 652:9                                      [_setRows]
packages/excel/src/save/save_file.dart 966:7                                      <fn>
dart-sdk/lib/_internal/js_dev_runtime/private/linked_hash_map.dart 21:7           forEach
packages/excel/src/save/save_file.dart 914:12                                     [_setSheetElements]
packages/excel/src/save/save_file.dart 544:5                                      [_save]
packages/excel/src/excel.dart 348:20