### PR TITLE
Fix of wrong calculation of new max rows if inserting a new row

### DIFF
--- a/lib/src/sheet/sheet.dart
+++ b/lib/src/sheet/sheet.dart
@@ -655,9 +655,9 @@ class Sheet {
     _sheetData = Map<int, Map<int, Data>>.from(_data);
 
     if (_maxRows - 1 <= rowIndex) {
-      _maxRows += 1;
-    } else {
       _maxRows = rowIndex + 1;
+    } else {
+      _maxRows += 1;
     }
 
     //_countRowsAndColumns();


### PR DESCRIPTION
in the insert row function of the sheet there is a bug as the two cases new row index > max rows and not are switched.