### PR TITLE
v4.0.6 - pubspec.yaml (archive: ^3.4.10)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: excel
 description: A flutter and dart library for reading, creating, editing and updating excel sheets with compatible both on client and server side.
-version: 4.0.5
+version: 4.0.6
 homepage: https://github.com/justkawal/excel
 topics:
   - excel
@@ -13,7 +13,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  archive: 3.4.9
+  archive: ^3.4.10
   xml: ">=5.0.0 <7.0.0"
   collection: ^1.15.0
   equatable: ^2.0.0


### PR DESCRIPTION
The use of a fixed version for "archive" will make it impossible to use the "excel" package with recent packages or projects using a newer version of "archive".