### PR TITLE
Rich Text support

### DIFF
--- a/lib/src/parser/parse.dart
+++ b/lib/src/parser/parse.dart
@@ -613,7 +613,7 @@ class Parser {
       case 's':
         final sharedString = _excel._sharedStrings
             .value(int.parse(_parseValue(node.findElements('v').first)));
-        value = TextCellValue(sharedString!.stringValue);
+        value = TextCellValue.span(sharedString!.textSpan);
         break;
       // boolean
       case 'b':

--- a/lib/src/save/save_file.dart
+++ b/lib/src/save/save_file.dart
@@ -48,11 +48,11 @@ class Save {
       CellValue? value, NumFormat? numberFormat) {
     SharedString? sharedString;
     if (value is TextCellValue) {
-      sharedString = _excel._sharedStrings.tryFind(value.value);
+      sharedString = _excel._sharedStrings.tryFind(value.toString());
       if (sharedString != null) {
-        _excel._sharedStrings.add(sharedString, value.value);
+        _excel._sharedStrings.add(sharedString, value.toString());
       } else {
-        sharedString = _excel._sharedStrings.addFromString(value.value);
+        sharedString = _excel._sharedStrings.addFromString(value.toString());
       }
     }
 

--- a/lib/src/sharedStrings/shared_strings.dart
+++ b/lib/src/sharedStrings/shared_strings.dart
@@ -78,6 +78,91 @@ class SharedString {
     return stringValue;
   }
 
+  TextSpan get textSpan {
+    bool getBool(XmlElement element) {
+      return bool.tryParse(element.getAttribute('val') ?? '') ?? true;
+    }
+
+    int getDouble(XmlElement element) {
+      // Should be double
+      return double.parse(element.getAttribute('val')!).toInt();
+    }
+
+    String? text;
+    List<TextSpan>? children;
+
+    /// SharedStringItem
+    /// https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.sharedstringitem?view=openxml-3.0.1
+    assert(node.localName == 'si'); //18.4.8 si (String Item)
+
+    for (final child in node.childElements) {
+      switch (child.localName) {
+        /// Text
+        /// https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.text?view=openxml-3.0.1
+        case 't': //18.4.12 t (Text)
+          text = (text ?? '') + child.innerText;
+          break;
+
+        /// Rich Text Run
+        /// https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.run?view=openxml-3.0.1
+        case 'r': //18.4.4 r (Rich Text Run)
+          var style = CellStyle();
+          for (final runChild in child.childElements) {
+            switch (runChild.localName) {
+              /// RunProperties
+              /// https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.runproperties?view=openxml-3.0.1
+              case 'rPr':
+                for (final runProperty in runChild.childElements) {
+                  switch (runProperty.localName) {
+                    case 'b': //18.8.2 b (Bold)
+                      style = style.copyWith(boldVal: getBool(runProperty));
+                      break;
+                    case 'i': //18.8.26 i (Italic)
+                      style = style.copyWith(italicVal: getBool(runProperty));
+                      break;
+                    case 'u': //18.4.13 u (Underline)
+                      style = style.copyWith(
+                          underlineVal:
+                              runProperty.getAttribute('val') == 'double'
+                                  ? Underline.Double
+                                  : Underline.Single);
+                      break;
+                    case 'sz': //18.4.11 sz (Font Size)
+                      style =
+                          style.copyWith(fontSizeVal: getDouble(runProperty));
+                      break;
+                    case 'rFont': //18.4.5 rFont (Font)
+                      style = style.copyWith(
+                          fontFamilyVal: runProperty.getAttribute('val'));
+                      break;
+                    case 'color': //18.3.1.15 color (Data Bar Color)
+                      style = style.copyWith(
+                          fontColorHexVal:
+                              runProperty.getAttribute('rgb')?.excelColor);
+                      break;
+                  }
+                }
+                break;
+
+              /// Text
+              case 't': //18.4.12 t (Text)
+                if (children == null) children = [];
+                children.add(TextSpan(text: runChild.innerText, style: style));
+                break;
+            }
+          }
+          break;
+
+        /// Phonetic Run
+        /// https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.phoneticrun?view=openxml-3.0.1
+        case 'rPh': //18.4.6 rPh (Phonetic Run)
+          break;
+      }
+    }
+
+    return TextSpan(text: text, children: children);
+  }
+
   String get stringValue {
     var buffer = StringBuffer();
     node.findAllElements('t').forEach((child) {
@@ -102,4 +187,34 @@ class SharedString {
   bool matches(String value) {
     return value.isNotEmpty && value == stringValue;
   }
+}
+
+class TextSpan {
+  final String? text;
+  final List<TextSpan>? children;
+  final CellStyle? style;
+
+  const TextSpan({this.children, this.text, this.style});
+
+  @override
+  String toString() {
+    String r = '';
+    if (text != null) r += text!;
+    if (children != null) r += children!.join();
+    return r;
+  }
+
+  @override
+  operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    return other is TextSpan &&
+        other.text == text &&
+        other.style == style &&
+        ListEquality().equals(other.children, children);
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(text, style, Object.hashAll(children ?? const []));
 }

--- a/lib/src/sheet/data_model.dart
+++ b/lib/src/sheet/data_model.dart
@@ -211,13 +211,14 @@ class DateCellValue extends CellValue {
 }
 
 class TextCellValue extends CellValue {
-  final String value;
+  final TextSpan value;
 
-  const TextCellValue(this.value);
+  TextCellValue(String text) : value = TextSpan(text: text);
+  TextCellValue.span(this.value);
 
   @override
   String toString() {
-    return value;
+    return value.toString();
   }
 
   @override

--- a/lib/src/sheet/sheet.dart
+++ b/lib/src/sheet/sheet.dart
@@ -1295,7 +1295,8 @@ class Sheet {
         if (sourceData is! TextCellValue) {
           continue;
         }
-        final result = sourceData.value.replaceAllMapped(source, (match) {
+        final result =
+            sourceData.value.toString().replaceAllMapped(source, (match) {
           if (first == -1 || first != replaceCount) {
             ++replaceCount;
             return match.input.replaceRange(match.start, match.end, target);


### PR DESCRIPTION
Implements Rich Text https://github.com/justkawal/excel/issues/320

`TextCellValue` uses a new `TextSpan` instead of a just `String`. It's similar to the one from Flutter, using `CellStyle` (even if only a few values can be changed)

`SharedString` has a new `textSpan` property that parses the String Item (si) node and creates the TextSpan according to the Run Properties (rPr).