### PR TITLE
Fixed xml package constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   archive: ^3.6.1
-  xml: ">=5.0.0 <7.0.0"
+  xml: ">=6.3.0 <7.0.0"
   collection: ^1.15.0
   equatable: ^2.0.0
 


### PR DESCRIPTION
Using the current `excel` version together with `xml` package below version 6.3.0 yields this error:


```
../../.pub-cache/hosted/pub.dev/excel-4.0.6/lib/src/parser/parse.dart:672:46: Error: The getter 'value' isn't defined for the class 'XmlText'.
 - 'XmlText' is from 'package:xml/src/xml/nodes/text.dart' ('../../.pub-cache/hosted/pub.dev/xml-5.4.1/lib/src/xml/nodes/text.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'value'.
        buffer.write(_normalizeNewLine(child.value));
                                             ^^^^^

```

See [xml changelog](https://pub.dev/packages/xml/changelog#630):

> Deprecate the ambiguous XmlNode.text: Replace with XmlNode.value to access the textual contents of the node, or XmlNode.innerText to access the textual contents of its descendants.
