### PR TITLE
feature: allow to create Array Formula

### DIFF
--- a/lib/src/save/save_file.dart
+++ b/lib/src/save/save_file.dart
@@ -94,8 +94,13 @@ class Save {
       case null:
         children = [];
       case FormulaCellValue():
+        final formulaAttributes = <XmlAttribute>[];
+        if (value.isArrayFormula) {
+          formulaAttributes.add(XmlAttribute(XmlName('t'), 'array'));
+          formulaAttributes.add(XmlAttribute(XmlName('ref'), '$rC:$rC'));
+        }
         children = [
-          XmlElement(XmlName('f'), [], [XmlText(value.formula)]),
+          XmlElement(XmlName('f'), formulaAttributes, [XmlText(value.formula)]),
           XmlElement(XmlName('v'), [], [XmlText('')]),
         ];
       case IntCellValue():

--- a/lib/src/sheet/data_model.dart
+++ b/lib/src/sheet/data_model.dart
@@ -113,8 +113,12 @@ sealed class CellValue {
 
 class FormulaCellValue extends CellValue {
   final String formula;
+  final bool isArrayFormula;
 
-  const FormulaCellValue(this.formula);
+  const FormulaCellValue(
+    this.formula, {
+    this.isArrayFormula = false,
+  });
 
   @override
   String toString() {


### PR DESCRIPTION
I required being able to create array formula ([excel docu example](https://support.microsoft.com/en-us/office/guidelines-and-examples-of-array-formulas-7d94a64e-3ff3-4686-9372-ecfd5caa57c7)) to get the correct result for my calculation.
I checked the generated xml with and without array formula and saw that two attributes had to be set, to get it working.

I DID NOT check the official SpreadSheetML documentation on this.

This PR is working, but also a piece for discussion, so please give me feedback if you so not like the code.