### PR TITLE
The issue with setMergedCellStyle function

### DIFF
--- a/lib/src/sheet/sheet.dart
+++ b/lib/src/sheet/sheet.dart
@@ -882,18 +882,19 @@ class Sheet {
         mergedCellStyle.rightBorder != Border() ||
         mergedCellStyle.diagonalBorderUp ||
         mergedCellStyle.diagonalBorderDown;
-    if (hasBorder) {
-      for (var i = start.rowIndex; i <= end.rowIndex; i++) {
-        for (var j = start.columnIndex; j <= end.columnIndex; j++) {
-          CellStyle cellStyle = mergedCellStyle.copyWith(
-            topBorderVal: Border(),
-            bottomBorderVal: Border(),
-            leftBorderVal: Border(),
-            rightBorderVal: Border(),
-            diagonalBorderUpVal: false,
-            diagonalBorderDownVal: false,
-          );
 
+    for (var i = start.rowIndex; i <= end.rowIndex; i++) {
+      for (var j = start.columnIndex; j <= end.columnIndex; j++) {
+        CellStyle cellStyle = mergedCellStyle.copyWith(
+          topBorderVal: Border(),
+          bottomBorderVal: Border(),
+          leftBorderVal: Border(),
+          rightBorderVal: Border(),
+          diagonalBorderUpVal: false,
+          diagonalBorderDownVal: false,
+        );
+
+        if (hasBorder) {
           if (i == start.rowIndex) {
             cellStyle = cellStyle.copyWith(
               topBorderVal: mergedCellStyle.topBorder,
@@ -923,13 +924,13 @@ class Sheet {
               diagonalBorderDownVal: mergedCellStyle.diagonalBorderDown,
             );
           }
+        }
 
-          if (i == start.rowIndex && j == start.columnIndex) {
-            cell(start).cellStyle = cellStyle;
-          } else {
-            _putData(i, j, null);
-            _sheetData[i]![j]!.cellStyle = cellStyle;
-          }
+        if (i == start.rowIndex && j == start.columnIndex) {
+          cell(start).cellStyle = cellStyle;
+        } else {
+          _putData(i, j, null);
+          _sheetData[i]![j]!.cellStyle = cellStyle;
         }
       }
     }

--- a/test/excel_test.dart
+++ b/test/excel_test.dart
@@ -1101,4 +1101,56 @@ void main() {
       reason: 'Decoding the file should not throw any exception',
     );
   });
+
+  group('Merged cells style', () {
+    final cellIndex1 = CellIndex.indexByString('A1');
+    final cellIndex2 = CellIndex.indexByString('B2');
+
+    late Excel excel;
+    late Sheet sheet;
+    late Border border;
+
+    setUp(() {
+      excel = Excel.createExcel();
+      sheet = excel['Sheet1'];
+      border = Border(
+        borderStyle: BorderStyle.Medium,
+        borderColorHex: ExcelColor.fromHexString('FFFF0000'),
+      );
+    });
+
+    actAndAssert(CellStyle style) {
+      sheet.merge(cellIndex1, cellIndex2);
+      sheet.setMergedCellStyle(cellIndex1, style);
+
+      for (var i = cellIndex1.rowIndex; i <= cellIndex2.rowIndex; i++)
+        for (var j = cellIndex1.columnIndex; j <= cellIndex2.columnIndex; j++) {
+          final cell = sheet.cell(
+            CellIndex.indexByColumnRow(columnIndex: j, rowIndex: i),
+          );
+          expect(cell.cellStyle, isNotNull,
+              reason: 'Cell style should be assigned to merged cells');
+        }
+    }
+
+    test('Assign a style with borders to merged cells', () {
+      final style = CellStyle(
+        backgroundColorHex: ExcelColor.fromHexString('FF00FF00'),
+        leftBorder: border,
+        rightBorder: border,
+        topBorder: border,
+        bottomBorder: border,
+      );
+
+      actAndAssert(style);
+    });
+
+    test('Assign a style without borders to merged cells', () {
+      final style = CellStyle(
+        backgroundColorHex: ExcelColor.fromHexString('FF00FF00'),
+      );
+
+      actAndAssert(style);
+    });
+  });
 }


### PR DESCRIPTION
### Problem
The `setMergedCellStyle` function doesn't apply **styles without borders** to merged cells. Styles without borders just ignored by the `if (hasBorder) `condition. 
### Solution
To solve the issue **the condition was moved into the loop**. We still need to make sure that the border surrounds all merged cells and also need to assign the style to cells that don't require borders.
In addition two unit tests were written to make sure that the style was assigned to all merged cells.
### Related issues
#304 
#282 