### PR TITLE
Avoid StateError in _parseStyles: check elements before using .single

### DIFF
--- a/lib/src/parser/parse.dart
+++ b/lib/src/parser/parse.dart
@@ -280,7 +280,15 @@ class Parser {
         for (var elementName in borderElementNamesList) {
           XmlElement? element;
           try {
-            element = node.findElements(elementName).single;
+            //element = node.findElements(elementName).single;
+
+            final elements = node.findElements(elementName);
+            if (elements.length == 1) {
+              element = elements.single;
+            } else {
+              element = null;
+            }
+            
           } on StateError catch (_) {
             // Either there is no element, or there are too many ones.
             // Silently ignore this element.


### PR DESCRIPTION
🐞 What is the bug?
The method _parseStyles throws a StateError: No element when it tries to call .single on the result of node.findElements(elementName). This happens when the XML element is missing or duplicated, causing the .single call to fail.

🔧 What was changed?
Replaced the unsafe usage of .single with a check that ensures exactly one element exists before accessing it. If not, the element is safely set to null.

Issues:

#374 