### PR TITLE
Flutter Web, wasm support fix

### DIFF
--- a/lib/excel.dart
+++ b/lib/excel.dart
@@ -7,8 +7,8 @@ import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:xml/xml.dart';
 import 'src/web_helper/client_save_excel.dart'
+    if (dart.library.js_interop) 'src/web_helper/wasm_web_save_excel_browser.dart'
     if (dart.library.html) 'src/web_helper/web_save_excel_browser.dart'
-    if (dart.library.js_interop) 'src/web_helper/web_save_excel_browser.dart'
     as helper;
 
 /// main directory

--- a/lib/excel.dart
+++ b/lib/excel.dart
@@ -8,6 +8,7 @@ import 'package:equatable/equatable.dart';
 import 'package:xml/xml.dart';
 import 'src/web_helper/client_save_excel.dart'
     if (dart.library.html) 'src/web_helper/web_save_excel_browser.dart'
+    if (dart.library.js_interop) 'src/web_helper/web_save_excel_browser.dart'
     as helper;
 
 /// main directory

--- a/lib/src/web_helper/wasm_web_save_excel_browser.dart
+++ b/lib/src/web_helper/wasm_web_save_excel_browser.dart
@@ -1,0 +1,37 @@
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:web/web.dart';
+
+class SavingHelper {
+  static List<int>? saveFile(List<int>? val, String fileName) {
+    if (val == null) {
+      return null;
+    }
+
+    // Create Uint8List
+    final uint8List = Uint8List.fromList(val);
+
+    // Convert to JS object properly
+    final jsData = uint8List.toJS;
+
+    // Create blob
+    final blob = Blob(
+        [jsData].toJS,
+        BlobPropertyBag(
+            type:
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'));
+
+    final url = URL.createObjectURL(blob);
+    final anchor = HTMLAnchorElement()
+      ..href = url
+      ..download = fileName;
+
+    document.body?.append(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+
+    return val;
+  }
+}


### PR DESCRIPTION
When running on Flutter `3.32.8` with `--web-experimental-hot-reload` flag enabled an error is thrown

```
Unsupported operation: inflateBuffer requires html or io.
main.dart.mjs:59     at module0.Error._throwWithCurrentStackTrace (http://localhost:56672/main.dart.wasm:wasm-function[952]:0x396fa6)
    at module0.inflateBuffer_ (http://localhost:56672/main.dart.wasm:wasm-function[61295]:0x820365)
    at module0.inflateBuffer (http://localhost:56672/main.dart.wasm:wasm-function[61203]:0x81dbd3)
    at module0.ZipFile.content (http://localhost:56672/main.dart.wasm:wasm-function[61195]:0x81d948)
    at module0.get forwarder for 'content' (http://localhost:56672/main.dart.wasm:wasm-function[61194]:0x81d866)
    at module0.ArchiveFile.content (http://localhost:56672/main.dart.wasm:wasm-function[60873]:0x8172ab)
    at module0.Parser._putContentXml (http://localhost:56672/main.dart.wasm:wasm-function[63105]:0x83f676)
    at module0.Parser._startParsing (http://localhost:56672/main.dart.wasm:wasm-function[63104]:0x83f5e5)
```

This fixes said issue, due to import misconfiguration on WASM enabled builds