### PR TITLE
FIX: adding line higher than current maxRows will delete data in the sheet

### DIFF
--- a/lib/src/sheet/sheet.dart
+++ b/lib/src/sheet/sheet.dart
@@ -664,6 +664,8 @@ class Sheet {
             });
           }
         });
+      } else {
+        _data = _sheetData;
       }
     }
     _data[rowIndex] = {0: Data.newData(this, rowIndex, 0)};


### PR DESCRIPTION
Currently if you use the function insertRow with an row index higher than maxRows - 1, will lead to data loss of the sheet data. This is because only in the case rowIndex <= maxRows - 1 the variable _data is filled, not in the other case. Later on the sheet data will be set with _data.