### PR TITLE
Fix null pointer exception for out-of-bounds sharedString indices

### DIFF
--- a/lib/src/parser/parse.dart
+++ b/lib/src/parser/parse.dart
@@ -489,8 +489,16 @@ class Parser {
     switch (type) {
       // sharedString
       case 's':
-        value = _excel._sharedStrings
-            .value(int.parse(_parseValue(node.findElements('v').first)));
+        final index = int.parse(_parseValue(node.findElements('v').first));
+        final sharedString = _excel._sharedStrings.value(index);
+        if (sharedString == null) {
+          // Handle missing sharedString gracefully (out-of-bounds index)
+          // This can happen when files are edited in Microsoft Excel on Windows
+          print('Warning: Cell references non-existent sharedString at index $index');
+          value = '';
+        } else {
+          value = sharedString;
+        }
         break;
       // boolean
       case 'b':


### PR DESCRIPTION
## Description
This PR fixes a critical null pointer exception that occurs when parsing Excel files that have been edited in Microsoft Excel on Windows.

## Problem
When Excel files are opened in Windows Excel with 'Enable Editing' and then saved, they can create sharedString references with out-of-bounds indices:
- The `xl/sharedStrings.xml` file might contain 415 entries (indices 0-414)
- A worksheet cell might reference sharedString index 415 (which doesn't exist)
- The `_SharedStringsMaintainer.value(index)` method returns `null` for out-of-bounds indices
- Code previously attempted to access the null value directly, causing a crash

## Solution
- Added null check for sharedString references before accessing them
- Returns empty string for cells with invalid sharedString references
- Added warning message to help identify problematic files during development
- Prevents application crashes when parsing real-world Excel files

## Impact
- **Severity**: High - Complete parsing failure on real-world files
- **Frequency**: Very common - happens with files edited in Windows Excel
- **User Experience**: Files that work initially now continue to work after normal editing workflow

## Testing
The fix gracefully handles missing sharedString entries and allows the parser to continue processing the file instead of crashing.

Fixes issue where Excel.decodeBytes() fails with: `DartError: Unexpected null value at parse.dart:491`